### PR TITLE
feat: self-hosted deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.git
+.github
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# AgentFlow - Self-hosted Docker build
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+
+COPY . .
+
+# Build for self-hosted (root path)
+ENV SITE_URL=http://localhost:3000
+ENV BASE_PATH=/
+RUN npm run build
+
+# Production: lightweight nginx
+FROM nginx:alpine
+COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -2,7 +2,40 @@
 
 エージェント組織設計ツール — 組織図エディタ → OpenClaw config エクスポート
 
-**Live**: https://agentflow.mtdnot1129.workers.dev
+**Live Demo**: https://frexida.github.io/agentflow/editor/
+
+## Quick Start
+
+### Option A: Docker (推奨)
+
+```bash
+git clone https://github.com/Frexida/agentflow.git
+cd agentflow
+docker compose up -d
+```
+
+→ http://localhost:3000/editor/ でアクセス
+
+### Option B: ローカルビルド
+
+```bash
+git clone https://github.com/Frexida/agentflow.git
+cd agentflow
+npm install
+SITE_URL=http://localhost:4321 BASE_PATH=/ npm run build
+```
+
+ビルド成果物 `dist/` を任意のWebサーバーで配信。
+
+開発モード:
+```bash
+npm run dev
+```
+
+### Option C: GitHub Pages (デプロイ不要)
+
+https://frexida.github.io/agentflow/editor/ をそのまま使用。
+データはブラウザのlocalStorageに保存されます。
 
 ## Features
 
@@ -47,26 +80,32 @@
 - **自動保存** — 5秒間隔でlocalStorageに保存
 - **手動保存** — 「💾 保存」ボタン
 
+## Self-Hosting
+
+### 環境変数
+
+| 変数 | デフォルト | 説明 |
+|------|-----------|------|
+| `SITE_URL` | `https://frexida.github.io` | サイトURL |
+| `BASE_PATH` | `/agentflow` | ベースパス（`/` でルート配信） |
+
+### Docker カスタマイズ
+
+ポート変更:
+```bash
+docker compose up -d  # デフォルト: 3000
+# または docker-compose.yml の ports を編集
+```
+
+### リバースプロキシ
+
+nginx/Caddy等の背後に置く場合、`SITE_URL` を実際のドメインに設定してビルド。
+
 ## Stack
 
-- **Astro** + **htmx** — SSR + 宣言的インタラクション
+- **Astro** — 静的サイトジェネレーター
 - **Drawflow** — ビジュアルノードエディタ
 - **dagre** — 自動レイアウトエンジン
-- **Cloudflare Workers** — エッジデプロイ
-
-## Development
-
-```bash
-npm install
-npm run dev
-```
-
-## Build & Deploy
-
-```bash
-npm run build
-npx wrangler deploy
-```
 
 ## Data Model
 
@@ -82,3 +121,7 @@ npx wrangler deploy
 `src/lib/export-openclaw.ts` — Organization → OpenClaw config JSON 変換
 
 生成されるconfigは OpenClaw の `config.apply` にそのまま使用可能。プレースホルダー（`REPLACE_WITH_*`）を実際のDiscord IDに置換してから適用。
+
+## License
+
+MIT

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,6 @@ import { defineConfig } from 'astro/config';
 // https://astro.build/config
 export default defineConfig({
   output: 'static',
-  site: 'https://frexida.github.io',
-  base: '/agentflow',
+  site: process.env.SITE_URL || 'https://frexida.github.io',
+  base: process.env.BASE_PATH || '/agentflow',
 });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  agentflow:
+    build: .
+    ports:
+      - "3000:80"
+    restart: unless-stopped

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff2?)$ {
+        expires 30d;
+        add_header Cache-Control "public, immutable";
+    }
+}


### PR DESCRIPTION
## Changes
- Dockerfile + docker-compose.yml for one-command Docker deploy
- nginx.conf for static file serving
- Configurable SITE_URL and BASE_PATH env vars in astro.config
- README rewritten with 3 deployment options (Docker / local build / GitHub Pages)
- .dockerignore for clean builds

## Deployment Options
| Option | Command | Target |
|--------|---------|--------|
| Docker | `docker compose up -d` | Self-hosted |
| Local | `npm run build` | Any web server |
| GitHub Pages | N/A | Already live |

## Testing
- ✅ Build verified with `BASE_PATH=/` (self-hosted)
- ✅ Default values preserve GitHub Pages compatibility