### PR TITLE
fix: use BASE_URL for all static asset paths

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -4,6 +4,7 @@ interface Props {
 }
 
 const { title = 'AgentFlow' } = Astro.props;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
 <!doctype html>
@@ -19,9 +20,9 @@ const { title = 'AgentFlow' } = Astro.props;
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="AgentFlow — Visual Agent Org Designer for OpenClaw" />
     <meta name="twitter:description" content="Design multi-agent teams visually. Org chart → OpenClaw config in one click." />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href={`${base}/favicon.svg`} />
     <title>{title}</title>
-    <script src="/htmx.min.js" is:inline></script>
+    <script src={`${base}/htmx.min.js`} is:inline></script>
   </head>
   <body>
     <slot />

--- a/src/pages/editor.astro
+++ b/src/pages/editor.astro
@@ -1,9 +1,10 @@
 ---
 import Base from '../layouts/Base.astro';
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
 <Base title="AgentFlow エディタ">
-  <link rel="stylesheet" href="/drawflow.min.css" />
+  <link rel="stylesheet" href={`${base}/drawflow.min.css`} />
   <style is:global>
     body { background: #0f0f0f; }
 
@@ -262,7 +263,7 @@ import Base from '../layouts/Base.astro';
 
   <div class="toast" id="toast"></div>
 
-  <script src="/drawflow.min.js" is:inline></script>
+  <script src={`${base}/drawflow.min.js`} is:inline></script>
   <script src="https://cdn.jsdelivr.net/npm/dagre@0.8.5/dist/dagre.min.js" is:inline></script>
   <script is:inline>
   (function() {


### PR DESCRIPTION
Static assets (drawflow, htmx, favicon) were hardcoded to root path. Now uses Astro BASE_URL so both GitHub Pages (/agentflow/) and self-hosted (/) work correctly.