### PR TITLE
fix: landing page editor link + BASE_URL consistency

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import Base from '../layouts/Base.astro';
-const base = import.meta.env.BASE_URL;
+const base = import.meta.env.BASE_URL.replace(/\/$/, '');
 ---
 
 <Base title="AgentFlow — Visual Agent Org Designer for OpenClaw">
@@ -12,7 +12,7 @@ const base = import.meta.env.BASE_URL;
       <p class="tagline">Design multi-agent teams visually.<br/>Org chart → OpenClaw config in one click.</p>
       <p class="sub">The first GUI for designing OpenClaw multi-agent organizations.<br/>No code. No YAML. Just drag, connect, export.</p>
       <div class="cta-row">
-        <a href={`${base}editor/`} class="cta primary">Try the Editor →</a>
+        <a href={`${base}/editor/`} class="cta primary">Try the Editor →</a>
         <a href="https://github.com/Frexida/agentflow" class="cta secondary" target="_blank">⭐ GitHub</a>
       </div>
     </section>
@@ -98,7 +98,7 @@ const base = import.meta.env.BASE_URL;
     <!-- CTA -->
     <section class="bottom-cta">
       <h2>Start designing your agent team</h2>
-      <a href={`${base}editor/`} class="cta primary">Open AgentFlow Editor →</a>
+      <a href={`${base}/editor/`} class="cta primary">Open AgentFlow Editor →</a>
     </section>
 
     <footer>


### PR DESCRIPTION
Fixes:
1. Landing page 'Try the Editor' link: /agentfloweditor/ → /agentflow/editor/
2. BASE_URL trailing slash handling in index.astro

Bug #2 (エージェント追加 not responding): Could not reproduce server-side. JS is valid, all functions present. Likely caused by cached old version or corrupt localStorage. Hard reload (Ctrl+Shift+R) or clearing site data should fix.